### PR TITLE
Fixes issue 505

### DIFF
--- a/Source/Core/Duality/GameObject.cs
+++ b/Source/Core/Duality/GameObject.cs
@@ -290,7 +290,7 @@ namespace Duality
 		/// <param name="parent"></param>
 		public GameObject(string name, GameObject parent = null)
 		{
-			this.name = name;
+			this.Name = name;
 			this.Parent = parent;
 		}
 		/// <summary>


### PR DESCRIPTION
Fixes a problem with creating null-named GameObjects through the GameObject() constructor. This directs the constructor to the method that checks for null or white space names and resolves them to "null".